### PR TITLE
fix memory leak in predict + predict_probability

### DIFF
--- a/ext/libsvm/libsvm.c
+++ b/ext/libsvm/libsvm.c
@@ -340,11 +340,13 @@ static VALUE cModel_predict(VALUE obj,VALUE example) {
   struct svm_node *x;
   struct svm_model *model;
   double class;
-  
+
   x = example_to_internal(example);
   Data_Get_Struct(obj, struct svm_model, model);
   class = svm_predict(model, x);
-  
+
+  free(x);
+
   return rb_float_new(class);
 }
 
@@ -371,6 +373,7 @@ static VALUE cModel_predict_probability(VALUE obj,VALUE example) {
     rb_ary_push(estimates, rx_from_double(c_estimates[i]));
 
   free(c_estimates);
+  free(x);
 
   target = rb_ary_new();
   rb_ary_push(target, rb_float_new(class));


### PR DESCRIPTION
So I wondered why my app wants 5GB of memory after ~100 training/evaluate-model cycles with a rather small number of trainings examples(3000). I started to investigate...

After eliminating my own code and libsvm itself I had an idea that it could be the wiring inside the rb-libsvm C-extension. Unfortunately Valgrind isn't much use in finding memory leak inside ruby or a ruby C-extension so I had to fall back to simple logging memory usage at specific codepoints. With success.
I could pinpoint it down to the evaluation of a libsvm model which meant a lot of calls to predict_probabilities. A quick exchange of predict_probabilities with just predict made sure that the leak had to be in both methods.

Long Story short the call to `example_to_internal` allocates memory for the nodes which later is never freed. Which mean if you call predict/predict_probablity often enough (30k) you end up with a quite a loot of wasted memory.

Apart from fixing the leak this should not interfere with anything else.
