### PR TITLE
The gem documentation is sparse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ tags
 *~
 /.rbx
 /vendor
+/.yardoc/
+/doc/

--- a/ext/libsvm/libsvm.c
+++ b/ext/libsvm/libsvm.c
@@ -411,6 +411,15 @@ static VALUE cModel_classes_count(VALUE obj)
   return INT2NUM(svm_get_nr_class(model));
 }
 
+/*
+ * Returns the number of the support vectors the model contains.
+ *
+ * This method binds to the function
+ * svm_get_nr_sv[https://github.com/cjlin1/libsvm/blob/master/README#L555]
+ * with the mode struct as an argument.
+ *
+ *   model.support_vectors_count # => 3
+ */
 static VALUE cModel_support_vectors_count(VALUE obj)
 {
   const struct svm_model *model;

--- a/ext/libsvm/libsvm.c
+++ b/ext/libsvm/libsvm.c
@@ -85,7 +85,7 @@ static struct svm_node *example_to_internal(VALUE example_ary)
   if(x == 0) {
     rb_raise(rb_eNoMemError, "on Libsvm::Node allocation" " %s:%i", __FILE__,__LINE__);
   }
-  /* loop it's element nodes */
+  /* loop its element nodes */
   for(j = 0; j < example_ary_len; ++j) {
     node = rb_ary_entry(example_ary,j);
     Data_Get_Struct(node,struct svm_node,node_struct);
@@ -122,12 +122,12 @@ static struct svm_node **examples_ary_to_internal(VALUE examples_ary)
    call-seq:
      problem.set_examples(labels, examples_array)
 
-     double *y;            // class (aka. label) of the example
-     struct svm_node **x;  // examples
+   Sets the examples and their label for a training set.
 
-   This method sets the contents of an SVM Problem, which consists
-   of lables (or classifications) and examples (or feature vectors).
-   If those 2 don't match in length and ArgumentError is raised.
+   The indices of the arrays are supposed to correspond. If they don't
+   match in length an ArgumentError is raised.
+
+   @return [Integer] number of examples in the traning set
 */
 static VALUE cProblem_examples_set(VALUE obj,VALUE labels_ary,VALUE examples_ary)
 {
@@ -167,10 +167,14 @@ static VALUE cProblem_examples_set(VALUE obj,VALUE labels_ary,VALUE examples_ary
 
 /*
    call-seq:
-   labels, array_of_arrays = problem.examples
+     problem.examples
 
-   double *y; // class/label of the example
-   struct svm_node **x;
+   Returns the array of labels and the array of corresponding examples
+   contained in this training set.
+
+     labels, array_of_examples = problem.examples
+
+   @return [[Array<Float>, Array<Array<Node>>]]
 */
 static VALUE cProblem_examples(VALUE problem) {
   struct svm_problem *prob;

--- a/ext/libsvm/libsvm.c
+++ b/ext/libsvm/libsvm.c
@@ -249,21 +249,6 @@ rx_def_accessor(cSvmParameter,struct svm_parameter,double,cache_size);
 rx_def_accessor(cSvmParameter,struct svm_parameter,double,eps);
 rx_def_accessor_as(cSvmParameter,struct svm_parameter,double,C,c);
 
-/*  Label weight.
-
-    nr_weight, weight_label, and weight are used to change the penalty
-    for some classes (If the weight for a class is not changed, it is
-    set to 1). This is useful for training classifier using unbalanced
-    input data or with asymmetric misclassification cost.
-
-    nr_weight is the number of elements in the array weight_label and
-    weight. Each weight[i] corresponds to weight_label[i], meaning that
-    the penalty of class weight_label[i] is scaled by a factor of weight[i].
-
-    If you do not want to change penalty for any of the classes,
-    just set nr_weight to 0.
-
-*/
 static VALUE cSvmParameter_label_weights_set(VALUE obj,VALUE weight_hash) {
   struct svm_parameter *param;
   int i;

--- a/ext/libsvm/libsvm.c
+++ b/ext/libsvm/libsvm.c
@@ -602,11 +602,31 @@ void Init_libsvm_ext() {
   rb_define_method(cModel, "predict", cModel_predict, 1);
   rb_define_method(cModel, "predict_probability", cModel_predict_probability, 1);
 
+  /**
+   * Module with constants for values that are allowed for
+   * {Libsvm::SvmParameter#kernel_type}. The value controls what kind
+   * of kernel is used when training the model.
+   */
   mKernelType = rb_define_module_under(mLibsvm, "KernelType");
+  /**
+   * A linear kernel
+   */
   rb_define_const(mKernelType, "LINEAR", INT2NUM(LINEAR));
+  /**
+   * A polynomial kernel
+   */
   rb_define_const(mKernelType, "POLY", INT2NUM(POLY));
+  /**
+   * A redial basis function kernel
+   */
   rb_define_const(mKernelType, "RBF", INT2NUM(RBF));
+  /**
+   * A sigmoid kernel
+   */
   rb_define_const(mKernelType, "SIGMOID", INT2NUM(SIGMOID));
+  /**
+   * A precomputed kernel
+   */
   rb_define_const(mKernelType, "PRECOMPUTED", INT2NUM(PRECOMPUTED));
 
   mSvmType = rb_define_module_under(mLibsvm,"SvmType");

--- a/ext/libsvm/libsvm.c
+++ b/ext/libsvm/libsvm.c
@@ -404,6 +404,13 @@ static VALUE cModel_svm_type(VALUE obj)
   return INT2NUM(svm_get_svm_type(model));
 }
 
+/*
+ * Return the nubmer of classes the model is configured and trained to
+ * predict. For single-class or regression models 2 is returned.
+ *
+ * This method binds to the function
+ * svm_get_nr_class[https://github.com/cjlin1/libsvm/blob/master/README#L538].
+ */
 static VALUE cModel_classes_count(VALUE obj)
 {
   const struct svm_model *model;

--- a/ext/libsvm/libsvm.c
+++ b/ext/libsvm/libsvm.c
@@ -430,8 +430,6 @@ static VALUE cModel_predict_probability(VALUE obj,VALUE example) {
  *
  * Library function
  * svm_save_model[https://github.com/cjlin1/libsvm/blob/master/README#L621].
- *
- * @return [nil]
  */
 static VALUE cModel_save(VALUE obj, VALUE filename)
 {

--- a/ext/libsvm/libsvm.c
+++ b/ext/libsvm/libsvm.c
@@ -381,6 +381,17 @@ static VALUE cModel_predict_probability(VALUE obj,VALUE example) {
   return target;
 }
 
+/* call-seq:
+ *   model.save(filename)
+ *
+ * Saves the model to file `filename`. The format is the LIBSVM
+ * internal model representation.
+ *
+ * Library function
+ * svm_save_model[https://github.com/cjlin1/libsvm/blob/master/README#L621].
+ *
+ * @return [nil]
+ */
 static VALUE cModel_save(VALUE obj, VALUE filename)
 {
   const struct svm_model *model;
@@ -397,6 +408,14 @@ static VALUE cModel_save(VALUE obj, VALUE filename)
   return Qnil;
 }
 
+/* Type of the model. Integer value, one of the constants in the
+ * {Libsvm::SvmType} module.
+ *
+ * Library function
+ * svm_get_svm_type[https://github.com/cjlin1/libsvm/blob/master/README#L533].
+ *
+ * @return [C_SVC, NU_SVC, ONE_CLASS, EPSILON_SVR, NU_SVR]
+ */
 static VALUE cModel_svm_type(VALUE obj)
 {
   const struct svm_model *model;
@@ -404,12 +423,13 @@ static VALUE cModel_svm_type(VALUE obj)
   return INT2NUM(svm_get_svm_type(model));
 }
 
-/*
- * Return the nubmer of classes the model is configured and trained to
+/* Number of classes the model is configured and trained to
  * predict. For single-class or regression models 2 is returned.
  *
- * This method binds to the function
+ * Library function
  * svm_get_nr_class[https://github.com/cjlin1/libsvm/blob/master/README#L538].
+ *
+ * @return [Integer] the number of classes
  */
 static VALUE cModel_classes_count(VALUE obj)
 {
@@ -419,13 +439,12 @@ static VALUE cModel_classes_count(VALUE obj)
 }
 
 /*
- * Returns the number of the support vectors the model contains.
+ * Number of the support vectors the model contains.
  *
  * This method binds to the function
- * svm_get_nr_sv[https://github.com/cjlin1/libsvm/blob/master/README#L555]
- * with the mode struct as an argument.
+ * svm_get_nr_sv[https://github.com/cjlin1/libsvm/blob/master/README#L555].
  *
- *   model.support_vectors_count # => 3
+ * @return [Integer] the number of support vectors
  */
 static VALUE cModel_support_vectors_count(VALUE obj)
 {
@@ -434,6 +453,17 @@ static VALUE cModel_support_vectors_count(VALUE obj)
   return INT2NUM(svm_get_nr_sv(model));
 }
 
+/* call-seq:
+ *   Model.load(filename)         # => model
+ *
+ * Load a {Libsvm::Model} from a file
+ *
+ * This load a model from file `filename`. Format is the LIBSVM
+ * internal file representation of the model.
+ *
+ * @param filename [String] name of the model file
+ * @return [Libsvm::Model] the model
+ */
 static VALUE cModel_class_load(VALUE cls, VALUE filename)
 {
   struct svm_model *model;
@@ -443,6 +473,17 @@ static VALUE cModel_class_load(VALUE cls, VALUE filename)
   return Data_Wrap_Struct(cModel, 0, model_free, model);
 }
 
+/* call-seq:
+ *   Model.cross_validation(problem, parameter, num_fold)
+ *
+ * Perform a cross-validation with num_fold split of the training data
+ * contained in problem.
+ *
+ * @param problem [Libsvm::Problem] the training set
+ * @param parameter [Libsvm::SvmParameter] training parameters object
+ * @param num_fold [Integer] the number of splits to devide the traning set into
+ * @return [Array<Integer>] the labels for each instance in training set
+ */
 static VALUE cModel_class_cross_validation(VALUE cls, VALUE problem, VALUE parameter, VALUE num_fold)
 {
   const struct svm_problem *prob;

--- a/ext/libsvm/libsvm.c
+++ b/ext/libsvm/libsvm.c
@@ -316,8 +316,20 @@ rx_def_accessor(cSvmParameter,struct svm_parameter,double,p);
 rx_def_accessor(cSvmParameter,struct svm_parameter,int,shrinking);
 rx_def_accessor(cSvmParameter,struct svm_parameter,int,probability);
 
-/*  Libsvm::Model  */
-
+/* call-seq:
+ *   Model.train(problem, parameter)
+ *
+ * Train a model with given training set (problem) and training
+ * parameter object.
+ *
+ * Library function
+ * svm_train[https://github.com/cjlin1/libsvm/blob/master/README#L313]
+ *
+ * @param [Libsvm::Problem] the training set (problem)
+ * @param [Libsvm::SvmParameter] training parameter object
+ *
+ * @return [Libsvm::Model] the trained model
+ */
 static VALUE cModel_class_train(VALUE obj,VALUE problem,VALUE parameter) {
   const struct svm_problem *prob;
   const struct svm_parameter *param;
@@ -336,6 +348,19 @@ static VALUE cModel_class_train(VALUE obj,VALUE problem,VALUE parameter) {
   return Data_Wrap_Struct(cModel, 0, model_free, model);
 }
 
+/* call-seq:
+ *   model.predict(example)
+ *
+ * Classify an example and return the class (label).
+ *
+ * This is the class (label) value for a classifier model or the
+ * funtion value for a regression model. 1 or -1 for one-class model.
+ *
+ * Library function
+ * svm_predict[https://github.com/cjlin1/libsvm/blob/master/README#L511].
+ *
+ * @return [Float] predicted class label
+ */
 static VALUE cModel_predict(VALUE obj,VALUE example) {
   struct svm_node *x;
   struct svm_model *model;
@@ -350,6 +375,22 @@ static VALUE cModel_predict(VALUE obj,VALUE example) {
   return rb_float_new(class);
 }
 
+/* call-seq:
+ *   model.predict_probability(example)
+ *
+ * Classify an example and return both the label (or regression
+ * value), as well as the array of probability found for each class.
+ *
+ * The first element of the returned array contains the label. The
+ * second element is another array which contains the probability
+ * value found for each model class.
+ *
+ * Library function
+ * svm_predict_probability[https://github.com/cjlin1/libsvm/blob/master/README#L591].
+ *
+ * @return [Array<Float, Array<Float>>] predicted label and
+ *   probability per class
+ */
 static VALUE cModel_predict_probability(VALUE obj,VALUE example) {
   struct svm_node *x;
   struct svm_model *model;

--- a/lib/libsvm.rb
+++ b/lib/libsvm.rb
@@ -5,6 +5,24 @@ require 'libsvm/node'
 module Libsvm
   module CoreExtensions
     module Collection
+      # @!method to_example
+      #
+      # Converts this collection into an array of feature.
+      #
+      #   { 1 => 0.4, 3 => 0.5, 5 => 0.9 }.to_example
+      #   # => [#<Libsvm::Node: index=1, value=0.4>, #<Libsvm::Node: index=3, value=0.5>, #<Libsvm::Node: index=5, value=0.9>]
+      #   { 1 => 0.4, 3 => 0.5, 5 => 0.9 }.to_example
+      #   # => [#<Libsvm::Node: index=1, value=0.4>, #<Libsvm::Node: index=3, value=0.5>, #<Libsvm::Node: index=5, value=0.9>]
+      #   [0.4, 0.5, 0.9].to_example
+      #   # => [#<Libsvm::Node: index=0, value=0.4>, #<Libsvm::Node: index=1, value=0.5>, #<Libsvm::Node: index=2, value=0.9>]
+      #   [ [1, 0.4], [3, 0.5], [5, 0.9] ].to_example
+      #   # => [#<Libsvm::Node: index=1, value=0.4>, #<Libsvm::Node: index=3, value=0.5>, #<Libsvm::Node: index=5, value=0.9>]
+      #
+      # An array of features is the type used for classification and model learning.
+      #
+      # @note In an upcoming major release this core extension will become no longer included in Hash and Array, but rather be optional.
+      #
+      # @return [Array<Libsvm::Node>]
       def to_example
         Node.features(self)
       end
@@ -15,6 +33,7 @@ end
 class Hash
   include Libsvm::CoreExtensions::Collection
 end
+
 class Array
   include Libsvm::CoreExtensions::Collection
 end

--- a/lib/libsvm.rb
+++ b/lib/libsvm.rb
@@ -3,6 +3,16 @@ require 'libsvm/libsvm_ext'
 require 'libsvm/node'
 
 module Libsvm
+
+  # Module with constants for values that allowed for
+  # {Libsvm::SvmParameter#svm_type}. The value controls which kind of
+  # model is being trained.
+  #
+  # See the relevant section in the LIBSVM
+  # README[https://github.com/cjlin1/libsvm/blob/master/README#389]
+  # for more information.
+  module SvmType; end
+
   module CoreExtensions
     module Collection
       # @!method to_example

--- a/lib/libsvm/model.rb
+++ b/lib/libsvm/model.rb
@@ -1,7 +1,9 @@
 module Libsvm
   class Model
+    # @deprecated Use {#classes_count} instead
     alias_method :classes, :classes_count
 
+    # @deprecated Use {#support_vectors_count} instead
     alias_method :support_vectors, :support_vectors_count
   end
 end

--- a/lib/libsvm/node.rb
+++ b/lib/libsvm/node.rb
@@ -17,11 +17,16 @@ module Libsvm
       # of float values.
       #
       # Indices are converted to Integer, values are converted to
-      # Float. When passed a variable number of Float values, the
-      # index is implied by the arguments position. Collection
-      # arguments afford sparse feature arrays.
+      # Float. When passed a variable number of Float values or an
+      # array of Floast, the index is implied by the arguments
+      # position. Collection of tuples of hash arguments afford sparse
+      # feature arrays. These can represent features which don't have
+      # consecutive indices starting at zero.
       #
       # @overload features(0.3, 0.7, 0.8, ...)
+      # @param vararg variable number of value arguments, or
+      #
+      # @overload features([0.3, 0.7, 0.8, ...])
       # @param array an array of values, or
       #
       # @overload features([[0, 0.3], [1, 0.7], [2, 0.8], ...])
@@ -30,7 +35,7 @@ module Libsvm
       # @overload features(0 => 0.3, 1 => 0.7, 2 => 0.8, 99 => 0.1)
       # @param hash a hash from index to value
       #
-      # @return [[Libsvm::Node]] example, i.e. an array of features
+      # @return [Array<Libsvm::Node>] example, i.e. an array of features
       def features(*vargs)
         array_of_nodes = []
         if vargs.size == 1
@@ -63,9 +68,9 @@ module Libsvm
 
       # Create a feature node.
       #
-      #   Libsvm::Node[0, 1.1] => #<Libsvm::Node:0x007fa58bb841c8>
+      #   Libsvm::Node[0, 1.1] # => #<Libsvm::Node: index=0, value=1.1>
       #
-      # @return (Libsvm::Node)
+      # @return [Libsvm::Node]
       def [](index, value)
         new(index, value)
       end
@@ -79,7 +84,7 @@ module Libsvm
 
     # Create a new feature node.
     #
-    #   Libsvm::Node.new(0, 1.1) => #<Libsvm::Node:0x007fa58bb84180>
+    #   Libsvm::Node.new(0, 1.1) # => #<Libsvm::Node: index=0, value=1.1>
     def initialize(index=0, value=0.0)
       self.index = index
       self.value = value

--- a/lib/libsvm/node.rb
+++ b/lib/libsvm/node.rb
@@ -34,12 +34,20 @@ module Libsvm
       def features(*vargs)
         array_of_nodes = []
         if vargs.size == 1
-          if vargs.first.class == Array
-            vargs.first.each_with_index do |value, index|
-              array_of_nodes << Node.new(index.to_i, value.to_f)
+          argument = vargs.first
+          if argument.class == Array
+            case argument.first
+            when Array
+              argument.each do |pair|
+                array_of_nodes << Node.new(pair.first.to_i, pair.last.to_f)
+              end
+            else
+              argument.each_with_index do |value, index|
+                array_of_nodes << Node.new(index.to_i, value.to_f)
+              end
             end
-          elsif vargs.first.class == Hash
-            vargs.first.each do |index, value|
+          elsif argument.class == Hash
+            argument.each do |index, value|
               array_of_nodes << Node.new(index.to_i, value.to_f)
             end
           else

--- a/lib/libsvm/node.rb
+++ b/lib/libsvm/node.rb
@@ -1,6 +1,36 @@
 module Libsvm
+  # Represents a feature
+  #
+  # A feature has an index and a value.
+  #
+  # An array of features (Libsvm::Node instances) represents an
+  # example which can be classified, or in greater number can
+  # constitute the main part of a training set (Libsvm::Prolem).
+  #
+  # This class represents the struct
+  # svm_node[https://github.com/cjlin1/libsvm/blob/master/README#L357].
+  #
+  # @see Libsvm::Problem Libsvm::Problem, the training set class
   class Node
     class << self
+      # Create an array of features from collection or variable number
+      # of float values.
+      #
+      # Indices are converted to Integer, values are converted to
+      # Float. When passed a variable number of Float values, the
+      # index is implied by the arguments position. Collection
+      # arguments afford sparse feature arrays.
+      #
+      # @overload features(0.3, 0.7, 0.8, ...)
+      # @param array an array of values, or
+      #
+      # @overload features([[0, 0.3], [1, 0.7], [2, 0.8], ...])
+      # @param array an array of [index, value] tuples, or
+      #
+      # @overload features(0 => 0.3, 1 => 0.7, 2 => 0.8, 99 => 0.1)
+      # @param hash a hash from index to value
+      #
+      # @return [[Libsvm::Node]] example, i.e. an array of features
       def features(*vargs)
         array_of_nodes = []
         if vargs.size == 1
@@ -23,16 +53,35 @@ module Libsvm
         array_of_nodes
       end
 
+      # Create a feature node.
+      #
+      #   Libsvm::Node[0, 1.1] => #<Libsvm::Node:0x007fa58bb841c8>
+      #
+      # @return (Libsvm::Node)
       def [](index, value)
         new(index, value)
       end
     end
 
+    # @!attribute index
+    #   The index identifies the feature for which this node represents a value
+
+    # @!attribute value
+    #   The value of this feature in this instance
+
+    # Create a new feature node.
+    #
+    #   Libsvm::Node.new(0, 1.1) => #<Libsvm::Node:0x007fa58bb84180>
     def initialize(index=0, value=0.0)
       self.index = index
       self.value = value
     end
 
+    # Compare features for equality.
+    #
+    # Nodes with equal index and value are equal.
+    #
+    # @return [Boolean]
     def ==(other)
       index == other.index && value == other.value
     end

--- a/lib/libsvm/node.rb
+++ b/lib/libsvm/node.rb
@@ -98,5 +98,12 @@ module Libsvm
     def ==(other)
       index == other.index && value == other.value
     end
+
+    def inspect # :nodoc:
+      vars = %w(index value).map { |name|
+        "#{name}=#{send(name)}"
+      }.join(", ")
+      "#<#{self.class}: #{vars}>"
+    end
   end
 end

--- a/lib/libsvm/problem.rb
+++ b/lib/libsvm/problem.rb
@@ -1,0 +1,20 @@
+module Libsvm
+  # This file only contains documentation comments. See
+  # ext/libsvm/libsvm.c for implementation.
+
+  # Represents a training set (alternatively called problem).
+  #
+  # In contains labels and examples in equal number.
+  #
+  # This class represents the struct
+  # svm_problem[https://github.com/cjlin1/libsvm/blob/master/README#L319].
+  class Problem
+
+    # @!attribute [r] l
+    #
+    # The number of labels and examples in this traning set. (The name
+    # is lower case L.)
+    #
+    # @return [Integer]
+  end
+end

--- a/lib/libsvm/svm_parameter.rb
+++ b/lib/libsvm/svm_parameter.rb
@@ -4,9 +4,68 @@ module Libsvm
 
   # Represents the learning parameter struct.
   #
+  # The parameters in this object control how the SVM model is trained
+  # specifically.
+  #
   # This class represents the struct
   # svm_parameter[https://github.com/cjlin1/libsvm/blob/master/README#L366].
-  module SvmParameter
+  class SvmParameter
+
+    # @!attribute svm_type
+    #
+    # Type of SVM to use. This parameter controls if the model
+    # classifies or performs regression, if a one-class model is
+    # built, or if the NU variant of SVM is used.
+    #
+    # @see Libsvm::SvmType Libsvm::SvmType for value constants
+    # @return [C_SVC, NU_SVC, ONE_CLASS, EPSILON_SVR, NU_SVR]
+
+    # @!attribute kernel_type
+    #
+    # Type of kernel to use.
+    #
+    # @see Libsvm::KernelType Libsvm::KernelType for kernel_type constants
+    # @return [LINEAR, POLY, RBF, SIGMOID, PRECOMPUTED]
+
+
+    # @!attribute degree
+    #
+    # Degree parameter, relevant for POLY kernel type.
+    #
+    # @see Libsvm::KernelType Libsvm::KernelType for kernel_type constants
+    # @return [Float]
+
+    # @!attribute gamma
+    #
+    # Gamma parameter, relevant for kernel types RBF, SIGMOID and POLY.
+    #
+    # @see Libsvm::KernelType Libsvm::KernelType for kernel_type constants
+    # @return [Float]
+
+    # @!attribute coef0
+    #
+    # Coeffectient 0, relevant for kernel types SIGMOID and POLY.
+    #
+    # @see Libsvm::KernelType Libsvm::KernelType for kernel_type constants
+    # @return [Float]
+
+    # @!attribute cache_size
+    #
+    # Size of the kernel cache, in mega-bytes.
+    #
+    # @return [Integer]
+
+    # @!attribute eps
+    #
+    # Stopping criterion parameter.
+    #
+    # @return [Float]
+
+    # @!attribute c
+    #
+    # The parameter C to use for this model.
+    #
+    # @return [Float]
 
     # @!attribute label_weights
     #
@@ -14,6 +73,43 @@ module Libsvm
     #
     # These weights are used to change the penalty for specific labels
     # (classes). If the weight for a label is not changed, it is set
-    # to 1.
+    # to 1.0.
+    #
+    # @return [Hash]
+
+    # @!attribute nu
+    #
+    # The nu parameter in nu-SVM, nu-SVR, and one-class-SVM (i.e. when
+    # the Libsvm::SvmParameter#svm_type is given as NU_SVC, NU_SVR or
+    # ONE_CLASS).
+    #
+    # @see Libsvm::SvmType Libsvm::SvmType for svm_type constants
+    # @return [Float]
+
+    # @!attribute p
+    #
+    # The epsilon in epsilon-insensitive loss function of epsilon-SVM
+    # regression (i.e. when the Libmsvm::SvmParameter#svm_type is
+    # given as Libsvm::SvmType::EPSILON_SVR).
+    #
+    # @return [Float]
+
+    # @!attribute shrinking
+    #
+    # Integer interpreted as boolean value.
+    #
+    # Controls if shrinking heuristics is used.
+    #
+    # @return [Integer] 0 meaning false, 1 true
+
+    # @!attribute probability
+    #
+    # Integer interpreted as boolean value.
+    #
+    # Controls if the model can create probability values for
+    # classifications in addition to the classification.
+    #
+    # @return [Integer] 0 meaning false, 1 true
+
   end
 end

--- a/lib/libsvm/svm_parameter.rb
+++ b/lib/libsvm/svm_parameter.rb
@@ -1,0 +1,19 @@
+module Libsvm
+  # This file only contains documentation comments. See
+  # ext/libsvm/libsvm.c for implementation.
+
+  # Represents the learning parameter struct.
+  #
+  # This class represents the struct
+  # svm_parameter[https://github.com/cjlin1/libsvm/blob/master/README#L366].
+  module SvmParameter
+
+    # @!attribute label_weights
+    #
+    # Hash with indices of labels as keys and weights as values.
+    #
+    # These weights are used to change the penalty for specific labels
+    # (classes). If the weight for a label is not changed, it is set
+    # to 1.
+  end
+end

--- a/lib/libsvm/svm_parameter.rb
+++ b/lib/libsvm/svm_parameter.rb
@@ -51,7 +51,7 @@ module Libsvm
 
     # @!attribute cache_size
     #
-    # Size of the kernel cache, in mega-bytes.
+    # Size of the kernel cache, in megabytes.
     #
     # @return [Integer]
 

--- a/lib/libsvm/svm_parameter.rb
+++ b/lib/libsvm/svm_parameter.rb
@@ -33,7 +33,7 @@ module Libsvm
     # Degree parameter, relevant for POLY kernel type.
     #
     # @see Libsvm::KernelType Libsvm::KernelType for kernel_type constants
-    # @return [Float]
+    # @return [Integer]
 
     # @!attribute gamma
     #

--- a/spec/core_ext_spec.rb
+++ b/spec/core_ext_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe "Create examples" do
   describe "from a hash" do
-    example = {11 => 0.11, 21 => 0.21, 101 => 0.99 }.to_example
-    example.should == Node.features({11 => 0.11, 21 => 0.21, 101 => 0.99 })
+    example = { 11 => 0.11, 21 => 0.21, 101 => 0.99 }.to_example.sort_by(&:index)
+    example.should == Node.features({11 => 0.11, 21 => 0.21, 101 => 0.99 }).sort_by(&:index)
   end
 
   describe "from an array of tuples" do
-    it "can create example from array" do
+    it "can create example from array of pairs" do
       example = [ [11, 0.11], [21, 0.21], [101, 0.99] ].to_example
-      example.should == Node.features({11 => 0.11, 21 => 0.21, 101 => 0.99 })
+      example.should == Node.features({11 => 0.11, 21 => 0.21, 101 => 0.99 }).sort_by(&:index)
     end
   end
 end

--- a/spec/core_ext_spec.rb
+++ b/spec/core_ext_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe "Create examples" do
+  describe "from a hash" do
+    example = {11 => 0.11, 21 => 0.21, 101 => 0.99 }.to_example
+    example.should == Node.features({11 => 0.11, 21 => 0.21, 101 => 0.99 })
+  end
+
+  describe "from an array of tuples" do
+    it "can create example from array" do
+      example = [ [11, 0.11], [21, 0.21], [101, 0.99] ].to_example
+      example.should == Node.features({11 => 0.11, 21 => 0.21, 101 => 0.99 })
+    end
+  end
+end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -47,12 +47,14 @@ describe "A Node" do
     ary = Node.features([0.1, 0.2, 0.3, 0.4, 0.5])
     ary.map {|n| n.class.should == Node}
     ary.map {|n| n.value }.should == [0.1, 0.2, 0.3, 0.4, 0.5]
+    ary.map {|n| n.index }.should == [0, 1, 2, 3, 4]
   end
 
   it "class can create nodes from variable parameters" do
     ary = Node.features(0.1, 0.2, 0.3, 0.4, 0.5)
     ary.map {|n| Node.should === n }
     ary.map {|n| n.value }.should == [0.1, 0.2, 0.3, 0.4, 0.5]
+    ary.map {|n| n.index }.should == [0, 1, 2, 3, 4]
   end
 
   it "class can create nodes from hash" do


### PR DESCRIPTION
Information I assume should be explained to a beginner doesn't seem to be easily accessible. For example, in both examples, the code

```ruby
parameter.cache_size = 1 # in megabytes
parameter.eps = 0.001
parameter.c   = 10
```

is not explained and only the first line is somehow self evident. Yet without these lines, the examples do not run (because they each default to 0). I assume `.c` corresponds to [the formula at libsvm's homepage](http://www.csie.ntu.edu.tw/~cjlin/papers/guide/guide.pdf) (PDF) ‘C’. I'm not sure about `.eps` (except that it's probably an epsilon).

Similarly, it's not obvious until you look deeper into the `.public_methods` that the [kernel type](http://rubydoc.info/gems/rb-libsvm/1.0.7/Libsvm/KernelType) should be set as a parameter passed to the model.

Another one is the presence of both an `examples` attribute and a `set_examples` method, with clear indications on how to use only the latter. It's not clear whether `set_examples` can accept data online, which I believe SVM should be able to handle.

The README should also probably mention the presence of more examples in the example folder.

Thanks for your work.

EDIT: 

Reading the source code a bit more, I found this:

```c
	double eps;	/* stopping criteria */
	double C;	/* for C_SVC, EPSILON_SVR and NU_SVR */
```

so I assume `eps` is used to determine if the last iteration made enough changes to the weight vector to warrant a new one (?)

EDIT2: I am currently reading the libsvm README and linking to it might be a good enough minimum.

It also indicates that the basic executable `svm-train` uses sensible defaults for epsilon, c, and the cache size, see:

```

-c cost : set the parameter C of C-SVC, epsilon-SVR, and nu-SVR (default 1)
...
-m cachesize : set cache memory size in MB (default 100)
-e epsilon : set tolerance of termination criterion (default 0.001)
```