### PR TITLE
Rename methods and alias old ones

### DIFF
--- a/ext/libsvm/libsvm.c
+++ b/ext/libsvm/libsvm.c
@@ -404,14 +404,14 @@ static VALUE cModel_svm_type(VALUE obj)
   return INT2NUM(svm_get_svm_type(model));
 }
 
-static VALUE cModel_classes(VALUE obj)
+static VALUE cModel_classes_count(VALUE obj)
 {
   const struct svm_model *model;
   Data_Get_Struct(obj, struct svm_model, model);
   return INT2NUM(svm_get_nr_class(model));
 }
 
-static VALUE cModel_support_vectors(VALUE obj)
+static VALUE cModel_support_vectors_count(VALUE obj)
 {
   const struct svm_model *model;
   Data_Get_Struct(obj, struct svm_model, model);
@@ -499,8 +499,8 @@ void Init_libsvm_ext() {
   rb_define_singleton_method(cModel, "load", cModel_class_load, 1);
   rb_define_method(cModel, "save", cModel_save, 1);
   rb_define_method(cModel, "svm_type", cModel_svm_type, 0);
-  rb_define_method(cModel, "classes", cModel_classes, 0);
-  rb_define_method(cModel, "support_vectors", cModel_support_vectors, 0);
+  rb_define_method(cModel, "classes_count", cModel_classes_count, 0);
+  rb_define_method(cModel, "support_vectors_count", cModel_support_vectors_count, 0);
   rb_define_method(cModel, "predict", cModel_predict, 1);
   rb_define_method(cModel, "predict_probability", cModel_predict_probability, 1);
 

--- a/lib/libsvm/model.rb
+++ b/lib/libsvm/model.rb
@@ -1,0 +1,7 @@
+module Libsvm
+  class Model
+    alias_method :classes, :classes_count
+
+    alias_method :support_vectors, :support_vectors_count
+  end
+end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -98,7 +98,7 @@ describe "A Libsvm model" do
     end
 
     it "can be asked for its number of classes (aka. labels)" do
-      expect(@model.classes).to eq(2)
+      expect(@model.classes_count).to eq(2)
     end
   end
 
@@ -108,9 +108,9 @@ describe "A Libsvm model" do
     end
   end
 
-  describe "support_vectors" do
+  describe "support_vectors_count" do
     it "returns count" do
-      expect(@model.support_vectors).to eq(3)
+      expect(@model.support_vectors_count).to eq(3)
     end
   end
 
@@ -124,7 +124,7 @@ describe "A Libsvm model" do
     end
 
     it "produces probabilities for each class" do
-      expect(probabilities.length).to eq(@model.classes)
+      expect(probabilities.length).to eq(@model.classes_count)
     end
 
     it "can predict probability" do


### PR DESCRIPTION
Some better method names. This PR renames

`Model#classes` to `Model#classes_count`
`Model#support_vectors` to `Model#support_vectors_count`

The problem with the current names is that they seem to imply to return collections of object where in reality they only return counts.

Old names are aliased to the new method in order to keep the interface from breaking.

Any thoughts?