### PR TITLE
Raise an IOError if model loading fails

### DIFF
--- a/ext/libsvm/libsvm.c
+++ b/ext/libsvm/libsvm.c
@@ -490,6 +490,8 @@ static VALUE cModel_support_vectors_count(VALUE obj)
  * internal file representation of the model.
  *
  * @param filename [String] name of the model file
+ * @raise [IOError] if the model can't be loaded,
+ *   e.g. because the model path doesn't point to a model
  * @return [Libsvm::Model] the model
  */
 static VALUE cModel_class_load(VALUE cls, VALUE filename)
@@ -498,6 +500,9 @@ static VALUE cModel_class_load(VALUE cls, VALUE filename)
   char *path;
   path = StringValueCStr(filename);
   model = svm_load_model(path);
+  if(model == NULL) {
+    rb_raise(rb_eIOError, "unable to load model from file: \"%s\"", path);
+  }
   return Data_Wrap_Struct(cModel, 0, model_free, model);
 }
 

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -70,6 +70,10 @@ describe "A saved model" do
     expect(Model.load(@filename)).to be_an_instance_of(Model)
   end
 
+  it "missing model raises exception" do
+    expect{Model.load("missing.model")}.to raise_error(IOError, /unable to load model from file: "missing.model"/)
+  end
+
   after(:each) do
     File.delete(@filename) rescue nil
   end


### PR DESCRIPTION
Before, a ruby object would be created which contained a null pointer as
content struct, resulting in segfault on an attempt to use for
prediction.

Fixes #21