### PR TITLE
Windows support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,11 +4,28 @@ require 'rspec/core/rake_task'
 
 task :default => :spec
 
-Rake::ExtensionTask.new('libsvm') do |ext|
-  ext.lib_dir = File.join('lib', 'libsvm')
+spec = eval File.read("rb-libsvm.gemspec")
+
+Gem::PackageTask.new(spec) do |pkg|
+end
+
+Rake::ExtensionTask.new('libsvm', spec) do |ext|
   ext.name = 'libsvm_ext'
+  ext.cross_compile = true
+
+  ext.cross_platform = ['x86-mingw32', 'x86-mswin32-60', 'x64-mingw32']
+
+  ext.cross_compiling do |gem_spec|
+    gem_spec.post_install_message = "You installed the binary version of this gem!"
+  end
 end
 
 RSpec::Core::RakeTask.new('spec')
 Rake::Task[:spec].prerequisites << :clean
 Rake::Task[:spec].prerequisites << :compile
+
+desc "windows gem"
+task 'gem:windows' do
+  require 'rake_compiler_dock'
+  RakeCompilerDock.sh "bundle && rake cross native gem RUBY_CC_VERSION=1.9.3:2.0.0:2.1.6:2.2.3 --trace"
+end

--- a/rb-libsvm.gemspec
+++ b/rb-libsvm.gemspec
@@ -14,12 +14,9 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "rb-libsvm"
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ["lib"]
-
-  s.add_development_dependency('rake-compiler')
+  s.add_development_dependency "rake", "~> 10.0.0"
+  s.add_development_dependency('rake-compiler', '~> 0.9.5')
+  s.add_development_dependency('rake-compiler-dock', '~> 0.4.0')
   s.add_development_dependency('rspec', '>= 3.0.0')
 
   s.extensions << 'ext/libsvm/extconf.rb'


### PR DESCRIPTION
This PR adds cross-compilation to Windows via Docker container and rake-compile-dock.

The command to build for windows is 

```
bundle exec rake gem:windows
```

We need confirmation that the packages run the tests successfully. Tests results are very welcome.

Implements #10 
